### PR TITLE
feat(slurmctld): add hardware info collection and update slurm.conf

### DIFF
--- a/ear.yml
+++ b/ear.yml
@@ -20,7 +20,12 @@
   tasks:
     - name: Verificar estado de los daemons EAR
       shell: |
+        export EAR_ETC={{ ear_etc }}
+        export EAR_INSTALL_PATH={{ ear_install_path }}
+        export EAR_TMP={{ ear_tmp }}
         {{ ear_install_path }}/bin/econtrol --status
+      args:
+        executable: /bin/bash
       register: ear_status
       changed_when: false
       ignore_errors: yes
@@ -31,7 +36,12 @@
         
     - name: Verificar reportes a la base de datos
       shell: |
+        export EAR_ETC={{ ear_etc }}
+        export EAR_INSTALL_PATH={{ ear_install_path }}
+        export EAR_TMP={{ ear_tmp }}
         {{ ear_install_path }}/bin/ereport -n all
+      args:
+        executable: /bin/bash
       register: ear_report
       changed_when: false
       ignore_errors: yes

--- a/inventory/hosts
+++ b/inventory/hosts
@@ -12,6 +12,7 @@ slurm01 ansible_host=192.168.1.137
 [compute]
 nodo01 ansible_host=192.168.1.140
 nodo02 ansible_host=192.168.1.138
+nodo03 ansible_host=192.168.1.148
 
 [login]
 login01 ansible_host=192.168.1.132

--- a/roles/ear/tasks/drivers_setup.yml
+++ b/roles/ear/tasks/drivers_setup.yml
@@ -1,0 +1,46 @@
+---
+- name: Verificar si el driver CPUFreq está cargado
+  shell: lsmod | grep acpi_cpufreq
+  register: cpufreq_loaded
+  changed_when: false
+  failed_when: false
+
+- name: Verificar si el driver IPMI está cargado
+  shell: lsmod | grep ipmi
+  register: ipmi_loaded
+  changed_when: false
+  failed_when: false
+
+- name: Cargar driver CPUFreq si no está cargado
+  shell: modprobe acpi-cpufreq
+  when: cpufreq_loaded.rc != 0
+  ignore_errors: yes
+
+- name: Cargar drivers IPMI si no están cargados
+  shell: |
+    modprobe ipmi_msghandler
+    modprobe ipmi_devintf
+    modprobe ipmi_si
+  when: ipmi_loaded.rc != 0
+  ignore_errors: yes
+
+- name: Configurar carga automática de drivers en el arranque
+  copy:
+    content: |
+      # Drivers requeridos por EAR
+      acpi-cpufreq
+      ipmi_msghandler
+      ipmi_devintf
+      ipmi_si
+    dest: "/etc/modules-load.d/ear-drivers.conf"
+    mode: '0644'
+
+- name: Verificar si los drivers están disponibles en el kernel
+  shell: |
+    find /lib/modules/$(uname -r) -name "acpi-cpufreq.ko" -o -name "ipmi_*.ko" | sort
+  register: drivers_available
+  changed_when: false
+
+- name: Mostrar drivers disponibles
+  debug:
+    var: drivers_available.stdout_lines

--- a/roles/ear/tasks/main.yml
+++ b/roles/ear/tasks/main.yml
@@ -16,6 +16,9 @@
     - "{{ ear_etc }}"
     - "/share/doc/ear"
 
+- name: Configurar drivers requeridos por EAR
+  include_tasks: drivers_setup.yml
+
 - name: Clonar repositorio EAR
   git:
     repo: "https://github.com/eas4dc/EAR.git"
@@ -61,6 +64,12 @@
   file:
     path: "{{ ear_etc }}/ear"
     state: directory
+    mode: '0755'
+
+- name: Crear archivo de variables de entorno para EAR
+  template:
+    src: ear_env.sh.j2
+    dest: "/etc/profile.d/ear_env.sh"
     mode: '0755'
 
 - name: Crear archivo ear.conf desde plantilla

--- a/roles/ear/templates/ear_env.sh.j2
+++ b/roles/ear/templates/ear_env.sh.j2
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Variables de entorno para EAR
+export EAR_INSTALL_PATH={{ ear_install_path }}
+export EAR_TMP={{ ear_tmp }}
+export EAR_ETC={{ ear_etc }}

--- a/roles/slurmctld/tasks/hardware_info.yml
+++ b/roles/slurmctld/tasks/hardware_info.yml
@@ -1,0 +1,59 @@
+---
+# Collect hardware information from compute nodes using Ansible's setup module
+- name: Collect hardware information from compute nodes
+  setup:
+    gather_subset:
+      - hardware
+  delegate_to: "{{ item }}"
+  delegate_facts: true
+  loop: "{{ groups['compute'] }}"
+
+# Set CPU-related variables for each node based on collected facts
+- name: Set CPU variables for each node
+  set_fact:
+    cpu_count: "{{ hostvars[item]['ansible_processor_count'] * hostvars[item]['ansible_processor_cores'] }}"
+    socket_count: "{{ hostvars[item]['ansible_processor_count'] }}"
+    cores_per_socket: "{{ hostvars[item]['ansible_processor_cores'] }}"
+    threads_per_core: "{{ hostvars[item]['ansible_processor_threads_per_core'] | default(1) }}"
+  delegate_to: "{{ item }}"
+  delegate_facts: true
+  loop: "{{ groups['compute'] }}"
+
+# Set memory variables for each node based on collected facts
+- name: Set memory variables for each node
+  set_fact:
+    total_memory_mb: "{{ hostvars[item]['ansible_memtotal_mb'] }}"
+  delegate_to: "{{ item }}"
+  delegate_facts: true
+  loop: "{{ groups['compute'] }}"
+
+# Get temporary disk information for each node (not available in Ansible facts)
+- name: Get temporary disk information for each node
+  shell: df -m /tmp | tail -1 | awk '{print $4}'
+  register: tmp_disk_output
+  changed_when: false
+  delegate_to: "{{ item }}"
+  loop: "{{ groups['compute'] }}"
+
+# Set temporary disk variable for each node
+- name: Set temporary disk variable for each node
+  set_fact:
+    tmp_disk_mb: "{{ tmp_disk_output.results[loop_index].stdout | int }}"
+  delegate_to: "{{ item }}"
+  delegate_facts: true
+  loop: "{{ groups['compute'] }}"
+  loop_control:
+    index_var: loop_index
+
+# Display collected hardware information for verification
+- name: Display collected hardware information for each node
+  debug:
+    msg: |
+      Node: {{ item }}
+      CPUs: {{ hostvars[item]['cpu_count'] }}
+      Sockets: {{ hostvars[item]['socket_count'] }}
+      Cores per socket: {{ hostvars[item]['cores_per_socket'] }}
+      Threads per core: {{ hostvars[item]['threads_per_core'] }}
+      Total memory (MB): {{ hostvars[item]['total_memory_mb'] }}
+      Temporary disk (MB): {{ hostvars[item]['tmp_disk_mb'] }}
+  loop: "{{ groups['compute'] }}"

--- a/roles/slurmctld/tasks/main.yml
+++ b/roles/slurmctld/tasks/main.yml
@@ -138,6 +138,12 @@
   meta: end_play
   when: not slurm_conf_template.stat.exists
 
+- name: Recopilar información de hardware de los nodos
+  include_tasks: hardware_info.yml
+  tags: 
+    - hardware_info
+    - slurm_config
+
 - name: Configure slurmctld
   template:
     src: slurm.conf.j2
@@ -200,4 +206,3 @@
     owner: slurm
     group: slurm
     mode: '0755'
-

--- a/roles/slurmctld/templates/slurm.conf.j2
+++ b/roles/slurmctld/templates/slurm.conf.j2
@@ -145,11 +145,7 @@ SlurmdLogFile=/var/log/slurm/slurmd.log
 #
 # COMPUTE NODES
 {% for node in groups['compute'] %}
-{% if node == groups['compute'][0] %}
-NodeName={{ node }} CPUs=12 RealMemory=31439 State=UNKNOWN Feature=highmem
-{% else %}
-NodeName={{ node }} CPUs=32 RealMemory=15692 State=UNKNOWN Feature=highcpu
-{% endif %}
+NodeName={{ node }} CPUs={{ hostvars[node]['cpu_count'] | default('32') }} Boards=1 SocketsPerBoard={{ hostvars[node]['socket_count'] | default('1') }} CoresPerSocket={{ hostvars[node]['cores_per_socket'] | default('16') }} ThreadsPerCore={{ hostvars[node]['threads_per_core'] | default('2') }} RealMemory={{ hostvars[node]['total_memory_mb'] | default('15692') }} TmpDisk={{ hostvars[node]['tmp_disk_mb'] | default('71616') }} State=UNKNOWN Feature={% if hostvars[node]['total_memory_mb'] | default('15692') | int > 30000 %}highmem{% else %}highcpu{% endif %}
 {% endfor %}
 
 # Partitions


### PR DESCRIPTION
This commit introduces the following changes:
- Add a new task `hardware_info.yml` to collect hardware information from compute nodes, including CPU, memory, and disk details.
- Update `slurm.conf.j2` template to dynamically configure nodes based on collected hardware facts.
- Add a new compute node `nodo03` to the inventory.
- Include `drivers_setup.yml` task to configure required drivers for EAR.
- Create `ear_env.sh.j2` template for EAR environment variables.
- Update shell commands in `ear.yml` to include EAR environment variables.